### PR TITLE
Remove usages of setenv

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -29,8 +29,8 @@ jobs:
     # Get date and store as environment variables
     - name: Get and store variables
       run: |
-        echo ::set-env name=BRANCH_NAME::$(date +%F)
-        echo ::set-env name=WEEK_OF::"Week of $(date '+%B %d, %Y')"
+        echo "BRANCH_NAME=$(date +%F)" >> $GITHUB_ENV
+        echo "WEEK_OF=$(date '+%B %d, %Y')" >> $GITHUB_ENV
 
     # Create meeting notes scaffold
     - name: Create weekly notes scaffold file

--- a/update_notes.sh
+++ b/update_notes.sh
@@ -1,6 +1,11 @@
 #! /bin/bash
 
 filename="meeting-notes/notes-$(date '+%B-%d-%Y').md"
+
+if [ -z "$(ls -A meeting-notes)" ]; then
+   mkdir meeting-notes
+fi
+
 cat <<- EOF >> "${filename}"
 
 ## $WEEK_OF


### PR DESCRIPTION
Using `setenv` is deprecated now and results in errors when the Action is run. Instead we should use the `$GITHUB_ENV` file instead to pass environment variables between stages.

More information [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).